### PR TITLE
Fix scan passthrough lineage with single-source fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ share/python-wheels/
 *.egg
 MANIFEST
 
+# temp repo
+.analysis
+
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
@@ -205,3 +208,4 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+.grepai/

--- a/src/polars_lineage/pipeline.py
+++ b/src/polars_lineage/pipeline.py
@@ -10,7 +10,7 @@ from polars_lineage.config import MappingConfig
 from polars_lineage.exporter import OutputFormat, RenderedLineage, export_lineage
 from polars_lineage.exporter.models import LineageDocument
 from polars_lineage.extractor.explain_tree import extract_plan_lineage
-from polars_lineage.ir import ColumnLineage
+from polars_lineage.ir import ColumnLineage, ColumnRef, DatasetRef
 from polars_lineage.resolver import resolve_transitive_lineage
 from polars_lineage.validation import validate_lineage
 
@@ -26,7 +26,30 @@ def extract_lineage_ir_from_lazyframe(
     lazyframe: pl.LazyFrame, mapping: MappingConfig
 ) -> list[ColumnLineage]:
     plan = lazyframe.explain(format="tree", optimized=False)
-    return extract_lineage_ir_from_plan(plan, mapping)
+    extracted = extract_plan_lineage(plan, mapping)
+
+    if len(mapping.sources) == 1:
+        output_columns = set(lazyframe.collect_schema().names())
+        covered_columns = {entry.to_column.column for entry in extracted}
+        passthrough_columns = sorted(output_columns - covered_columns)
+        if passthrough_columns:
+            source_dataset = DatasetRef.from_fqn(next(iter(mapping.sources.values())))
+            destination_dataset = DatasetRef.from_fqn(mapping.destination_table)
+            extracted.extend(
+                [
+                    ColumnLineage(
+                        from_columns=(ColumnRef(dataset=source_dataset, column=column_name),),
+                        to_column=ColumnRef(dataset=destination_dataset, column=column_name),
+                        function=f'col("{column_name}")',
+                        confidence="inferred",
+                    )
+                    for column_name in passthrough_columns
+                ]
+            )
+
+    resolved = resolve_transitive_lineage(extracted)
+    validate_lineage(resolved)
+    return resolved
 
 
 def extract_lineage_output_from_plan(

--- a/tests/e2e/test_pipeline.py
+++ b/tests/e2e/test_pipeline.py
@@ -1,4 +1,8 @@
+from datetime import date
+import json
+
 import polars as pl
+import pytest
 
 import polars_lineage
 
@@ -63,3 +67,54 @@ def test_e2e_does_not_emit_self_lineage_for_literal_columns() -> None:
     for payload in payloads:
         for entry in payload["edge"]["lineageDetails"]["columnsLineage"]:
             assert not (entry["toColumn"] == "one" and entry["fromColumns"] == ["one"])
+
+
+def _assert_static_today_scan_lineage(
+    lazyframe: pl.LazyFrame, source_name: str, source_uri: str
+) -> None:
+    lazyframe = _lineage(lazyframe).add_source(
+        name=source_name,
+        uri=source_uri,
+        destination_table="svc.db.curated.orders_parquet",
+    )
+    transformed = lazyframe.with_columns(pl.lit(date.today()).alias("loaded_at"))
+    assert transformed.collect_schema().names() == ["id", "sku", "qty", "loaded_at"]
+    payloads = _lineage(transformed).extract()
+    assert len(payloads) == 1
+    columns_lineage = payloads[0]["edge"]["lineageDetails"]["columnsLineage"]
+    to_columns = {item["toColumn"] for item in columns_lineage}
+    assert to_columns == {"id", "sku", "qty"}
+    assert "loaded_at" not in to_columns
+
+
+@pytest.mark.parametrize("scan_kind", ["csv", "parquet", "ndjson", "json"])
+def test_e2e_scan_inputs_with_static_today_column_preserve_source_lineage(
+    tmp_path,
+    scan_kind: str,
+) -> None:
+    frame = pl.DataFrame({"id": [1], "sku": ["A"], "qty": [2]})
+
+    if scan_kind == "csv":
+        source_path = tmp_path / "orders.csv"
+        source_path.write_text("id,sku,qty\n1,A,2\n", encoding="utf-8")
+        lazyframe = pl.scan_csv(str(source_path))
+    elif scan_kind == "parquet":
+        source_path = tmp_path / "orders.parquet"
+        frame.write_parquet(source_path)
+        lazyframe = pl.scan_parquet(str(source_path))
+    elif scan_kind == "ndjson":
+        source_path = tmp_path / "orders.ndjson"
+        frame.write_ndjson(source_path)
+        lazyframe = pl.scan_ndjson(str(source_path))
+    else:
+        if not hasattr(pl, "scan_json"):
+            pytest.skip("polars scan_json is not available in this version")
+        source_path = tmp_path / "orders.json"
+        source_path.write_text(json.dumps([{"id": 1, "sku": "A", "qty": 2}]), encoding="utf-8")
+        lazyframe = pl.scan_json(str(source_path))
+
+    _assert_static_today_scan_lineage(
+        lazyframe=lazyframe,
+        source_name=f"orders_{scan_kind}",
+        source_uri=f"s3://warehouse/raw/orders.{scan_kind}",
+    )

--- a/tests/e2e/test_pipeline.py
+++ b/tests/e2e/test_pipeline.py
@@ -1,5 +1,5 @@
-from datetime import date
 import json
+from datetime import date
 
 import polars as pl
 import pytest

--- a/uv.lock
+++ b/uv.lock
@@ -172,7 +172,7 @@ wheels = [
 
 [[package]]
 name = "polars-lineage"
-version = "0.1.5"
+version = "0.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "polars" },


### PR DESCRIPTION
## Summary
- add a single-source fallback in lazyframe extraction to emit inferred passthrough lineage for output columns not covered by explain-tree parsing
- add an e2e scan-matrix test (`csv`, `parquet`, `ndjson`, optional `json`) for flows that append a static `loaded_at` column
- verify static literal columns are excluded from `columnsLineage` while source-backed passthrough columns remain present

## Testing
- `uv run pytest tests/e2e/test_pipeline.py -q`
- `uv run pytest -q`

Closes #21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lineage extraction to infer pass-through columns from a single source and always resolve/validate transitive lineage.

* **Tests**
  * Expanded end-to-end tests to verify lineage preservation across CSV, Parquet, NDJSON, and JSON, including ensuring static "today" columns are excluded from tracked columns.

* **Chores**
  * Added new ignore entries for temporary tooling/output directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->